### PR TITLE
Typo fix, small start script change

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,15 @@ Inertia is a <em>free</em>, <em>privacy-respecting</em>, and <em>stylish</em> me
    $ bin/rails credentials:edit
    ```
 
-5. You can now launch Inertia with the `scripts/production.sh` script.
+5. You can now launch Inertia with the `scripts/production.sh` script.  
+   If you want to use another port instead of the default one (3000), specify it as the first argument.
+   ```shell
+   # Run inertia on the default port (3000)
+   $ sh scripts/production.sh
+
+   # Run inertia on the port 1234
+   $ sh scripts/production.sh 1234
+   ```
 
 ### Setup Inertia (Using Docker)
 

--- a/app/views/search/opensearch.xml.erb
+++ b/app/views/search/opensearch.xml.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
-    xmlns:moz="http://www.mozzilla.org/2006/browser/search/">
+    xmlns:moz="http://www.mozilla.org/2006/browser/search/">
     <ShortName>Inertia</ShortName>
     <LongName>Inertia Search</LongName>
     <Description>Inertia is a free, privacy-respecting, and stylish meta-search engine</Description>

--- a/scripts/production.sh
+++ b/scripts/production.sh
@@ -13,5 +13,11 @@ if ! RAILS_ENV=production bundle exec rails assets:precompile; then
   exit 1
 fi
 
+echo -e '\e[32mApplying arguments...\e[0m'
+cmd="production bundle exec rails server"
+if [ ! -z "$1" ]; then
+  cmd="$cmd -p $1"
+fi
+
 echo -e '\e[32mLaunching Server...\e[0m'
-RAILS_ENV=production bundle exec rails server
+exec "RAILS_ENV=$cmd"


### PR DESCRIPTION
Yo, here are the changes i've made:
- I fixed a small mozilla (previously "mozzilla") typo in `opensearch.xml`
- I made it so you can now specify a new port as an argument when starting Inertia.
- I added a small section in `README.md` where I explain how the change above works.